### PR TITLE
docs: expose api reference at docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,9 +39,14 @@ pnpm dev
 Local services:
 
 - API: `http://localhost:3000`
-- API docs: `http://localhost:3000/api-docs/docs`
+- API docs: `http://localhost:3000/docs`
 - PostgreSQL: `localhost:5432`
 - pgAdmin: `http://localhost:5050`
+
+Production:
+
+- API: <https://parkcore-api.onrender.com/>
+- API docs: <https://parkcore-api.onrender.com/docs>
 
 ## Scripts
 

--- a/docs/API-DESIGN.md
+++ b/docs/API-DESIGN.md
@@ -62,6 +62,6 @@ Configuration:
 
 ## OpenAPI
 
-- UI: `/api-docs/docs`
-- JSON: `/api-docs/openapi.json`
+- UI: `/docs`
+- JSON: `/openapi.json`
 - Production docs require `ENABLE_API_DOCS=true`

--- a/src/config/api-docs.ts
+++ b/src/config/api-docs.ts
@@ -21,9 +21,11 @@ const docsHelmet = helmet({
   },
 });
 
-export const docsBasePath = '/api-docs';
-export const docsUiPath = `${docsBasePath}/docs`;
-export const docsSpecPath = `${docsBasePath}/openapi.json`;
+export const docsUiPath = '/docs';
+export const docsSpecPath = '/openapi.json';
+
+const legacyDocsUiPath = '/api-docs/docs';
+const legacyDocsSpecPath = '/api-docs/openapi.json';
 
 export function mountApiDocs(app: Express, openApiSpec: object): void {
   app.use(
@@ -41,11 +43,11 @@ export function mountApiDocs(app: Express, openApiSpec: object): void {
     res.json(openApiSpec);
   });
 
-  app.get('/docs', (_req, res) => {
+  app.get(legacyDocsUiPath, (_req, res) => {
     res.redirect(308, docsUiPath);
   });
 
-  app.get('/openapi.json', (_req, res) => {
+  app.get(legacyDocsSpecPath, (_req, res) => {
     res.redirect(308, docsSpecPath);
   });
 }

--- a/src/scripts/smoke-api.ts
+++ b/src/scripts/smoke-api.ts
@@ -64,7 +64,7 @@ async function checkHealth(): Promise<void> {
 }
 
 async function checkDocs(): Promise<void> {
-  const docsPaths = ['/api-docs/openapi.json', '/openapi.json'];
+  const docsPaths = ['/openapi.json', '/api-docs/openapi.json'];
   let result: HttpResult | null = null;
 
   for (const path of docsPaths) {
@@ -77,7 +77,7 @@ async function checkDocs(): Promise<void> {
 
   assert(
     result !== null,
-    'OpenAPI endpoint not reachable (checked /api-docs/openapi.json and /openapi.json)',
+    'OpenAPI endpoint not reachable (checked /openapi.json and /api-docs/openapi.json)',
   );
   const json = result.json;
   assert(json !== null, 'OpenAPI document body is not JSON');

--- a/src/scripts/smoke-local.ts
+++ b/src/scripts/smoke-local.ts
@@ -35,12 +35,9 @@ async function main(): Promise<void> {
   assert(health.status === 200, `GET /healthz expected 200, got ${String(health.status)}`);
   assert(healthBody.status === 'ok', 'GET /healthz expected body.status === "ok"');
 
-  const docs = await request(app).get('/api-docs/openapi.json');
+  const docs = await request(app).get('/openapi.json');
   const docsBody = parseJsonBody(docs);
-  assert(
-    docs.status === 200,
-    `GET /api-docs/openapi.json expected 200, got ${String(docs.status)}`,
-  );
+  assert(docs.status === 200, `GET /openapi.json expected 200, got ${String(docs.status)}`);
   assert(typeof docsBody.openapi === 'string', 'OpenAPI document missing "openapi" field');
   assert(typeof docsBody.info === 'object', 'OpenAPI document missing "info" field');
 


### PR DESCRIPTION
## Summary
- Make `/docs` and `/openapi.json` the canonical API documentation routes.
- Keep `/api-docs/docs` and `/api-docs/openapi.json` as 308 redirects for compatibility.
- Add production Render links to the README.

## Verification
- `pnpm format:check`
- `pnpm test` (13 files, 76 tests)
- `pnpm release:readiness`
- `pnpm quality:ci`